### PR TITLE
refactor(ui): extract constants and styles to separate files

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,58 @@
+package main
+
+// Color constants
+const (
+	// Primary theme colors
+	ColorPrimary     = "#6f7cbf"
+	ColorBackground  = "#282a36"
+	ColorForeground  = "#f8f8f2"
+	ColorSelection   = "#44475a"
+	ColorHighlight   = "#a600a0"
+	ColorAccent      = "#89b4fa"
+	ColorText        = "#cdd6f4"
+	ColorBorder      = "#6f7cbf"
+	
+	// Status message colors
+	ColorSuccess     = "#ff00b3"
+	ColorError       = "#800024"
+	ColorWarning     = "#e3e094"
+	ColorInfo        = "#00ffe1"
+	
+	// UI element colors
+	ColorMinibuffer  = "#b889fa"
+	ColorMinibufferBg = "#1e1e2e"
+	ColorWhitespace  = "236"
+	ColorMuted       = "240"
+	ColorDim         = "241"
+	ColorBright      = "230"
+	ColorAlert       = "196"
+)
+
+// UI layout constants
+const (
+	KeyColumnWidth        = 18
+	HelpMaxWidthPercent   = 40
+	HelpMinWidth          = 50
+	StatusBarSections     = 3
+	SearchContextLength   = 30
+	LinePreviewMaxLength  = 70
+	LinePreviewTruncate   = 67
+	
+	// Minimum terminal size constraints
+	MinTerminalWidth      = 40
+	MinTerminalHeight     = 10
+	MinLineNumberWidth    = 6  // "  999 " format
+	MinContentWidth       = 20 // Minimum usable content area
+)
+
+// Editor behavior constants
+const (
+	MaxHistorySize        = 100
+	TickIntervalMs        = 500
+	FilePermissions       = 0644
+)
+
+// ANSI escape sequences
+const (
+	ClearScreen = "\033[2J\033[H"
+)

--- a/handlers.go
+++ b/handlers.go
@@ -15,12 +15,12 @@ func (m Model) handleSave() (tea.Model, tea.Cmd) {
 			m.modified = false
 			m.originalText = m.textBuffer.GetContent()
 			m.lastSaved = time.Now()
-			m.setMessage(lipgloss.NewStyle().Foreground(lipgloss.Color("#ff00b3")).Render("File saved successfully"))
+			m.setMessage(lipgloss.NewStyle().Foreground(lipgloss.Color(ColorSuccess)).Render("File saved successfully"))
 		} else {
-			m.setMessage(lipgloss.NewStyle().Foreground(lipgloss.Color("#800024")).Render(fmt.Sprintf("Error saving file: %v", err)))
+			m.setMessage(lipgloss.NewStyle().Foreground(lipgloss.Color(ColorError)).Render(fmt.Sprintf("Error saving file: %v", err)))
 		}
 	} else {
-		m.setMessage(lipgloss.NewStyle().Foreground(lipgloss.Color("#e3e094")).Render("No filename specified"))
+		m.setMessage(lipgloss.NewStyle().Foreground(lipgloss.Color(ColorWarning)).Render("No filename specified"))
 	}
 	return m, nil
 }

--- a/main.go
+++ b/main.go
@@ -6,59 +6,9 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
-var (
-	statusBarStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("#6f7cbf")).
-			Foreground(lipgloss.Color("230")).
-			Padding(0, 1)
-
-	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241"))
-
-	modifiedStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("#6f7cbf")).
-			Foreground(lipgloss.Color("196")).
-			Bold(true)
-
-	editorStyle = lipgloss.NewStyle().
-			Border(lipgloss.ThickBorder()).
-			BorderForeground(lipgloss.Color("#6f7cbf")).
-			Padding(0, 1)
-
-	lineNumberStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240")).
-			Width(4).
-			Align(lipgloss.Right)
-
-	selectedTextStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color("#a600a0")).
-				Foreground(lipgloss.Color("#f8f8f2"))
-
-	cursorLineStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("#282a36"))
-
-	helpBoxStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#6f7cbf")).
-			AlignHorizontal(lipgloss.Center).
-			Padding(1, 2).
-			Margin(1, 0)
-
-	helpTitleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#6f7cbf")).
-			Bold(true).
-			Underline(true)
-
-	helpKeyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#89b4fa")).
-			Bold(true)
-
-	helpDescStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#cdd6f4"))
-)
+// Styles are now defined in styles.go
 
 type Model struct {
 	textBuffer          *TextBuffer
@@ -121,7 +71,7 @@ func NewModel(filename string) Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Tick(time.Millisecond*500, func(t time.Time) tea.Msg {
+	return tea.Tick(time.Millisecond*TickIntervalMs, func(t time.Time) tea.Msg {
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{}}
 	})
 }
@@ -140,5 +90,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Print("\033[2J\033[H")
+	fmt.Print(ClearScreen)
 }

--- a/minibuffer.go
+++ b/minibuffer.go
@@ -6,34 +6,9 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
-var (
-	minibufferStyle = lipgloss.NewStyle().
-			Background(lipgloss.Color("#44475a")).
-			Foreground(lipgloss.Color("#f8f8f2")).
-			Padding(0, 1)
-
-	minibufferPromptStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#89b4fa")).
-				Bold(true)
-
-	minibufferInputStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#f8f8f2"))
-
-	minibufferCursorStyle = lipgloss.NewStyle().
-				Background(lipgloss.Color("#f8f8f2")).
-				Foreground(lipgloss.Color("#282a36"))
-
-	searchResultSelectedStyle = lipgloss.NewStyle().
-					Background(lipgloss.Color("#b889fa")).
-					Foreground(lipgloss.Color("#1e1e2e")).
-					Bold(true)
-
-	searchResultNormalStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#00ffe1"))
-)
+// Styles are now defined in styles.go
 
 type MinibufferType int
 
@@ -224,17 +199,17 @@ func (m Model) renderGoToLineMinibuffer() string {
 	var inputDisplay strings.Builder
 	for i, char := range m.minibufferInput {
 		if i == m.minibufferCursorPos {
-			inputDisplay.WriteString(minibufferCursorStyle.Render(string(char)))
+			inputDisplay.WriteString(MinibufferCursorStyle.Render(string(char)))
 		} else {
 			inputDisplay.WriteString(string(char))
 		}
 	}
 
 	if m.minibufferCursorPos >= len(m.minibufferInput) {
-		inputDisplay.WriteString(minibufferCursorStyle.Render(" "))
+		inputDisplay.WriteString(MinibufferCursorStyle.Render(" "))
 	}
 
-	content := minibufferPromptStyle.Render(prompt) + minibufferInputStyle.Render(inputDisplay.String())
+	content := MinibufferPromptStyle.Render(prompt) + MinibufferInputStyle.Render(inputDisplay.String())
 
 	minibufferWidth := m.width - 4
 	currentLen := len(prompt) + len(m.minibufferInput)
@@ -243,7 +218,7 @@ func (m Model) renderGoToLineMinibuffer() string {
 		content += padding
 	}
 
-	return minibufferStyle.Width(m.width - 2).Render(content)
+	return MinibufferStyle.Width(m.width - 2).Render(content)
 }
 
 func (m Model) renderFindMinibuffer() string {
@@ -252,17 +227,17 @@ func (m Model) renderFindMinibuffer() string {
 	var inputDisplay strings.Builder
 	for i, char := range m.minibufferInput {
 		if i == m.minibufferCursorPos {
-			inputDisplay.WriteString(minibufferCursorStyle.Render(string(char)))
+			inputDisplay.WriteString(MinibufferCursorStyle.Render(string(char)))
 		} else {
 			inputDisplay.WriteString(string(char))
 		}
 	}
 
 	if m.minibufferCursorPos >= len(m.minibufferInput) {
-		inputDisplay.WriteString(minibufferCursorStyle.Render(" "))
+		inputDisplay.WriteString(MinibufferCursorStyle.Render(" "))
 	}
 
-	content := minibufferPromptStyle.Render(prompt) + minibufferInputStyle.Render(inputDisplay.String())
+	content := MinibufferPromptStyle.Render(prompt) + MinibufferInputStyle.Render(inputDisplay.String())
 
 	minibufferWidth := m.width - 4
 	currentLen := len(prompt) + len(m.minibufferInput)
@@ -271,7 +246,7 @@ func (m Model) renderFindMinibuffer() string {
 		content += padding
 	}
 
-	return minibufferStyle.Width(m.width - 2).Render(content)
+	return MinibufferStyle.Width(m.width - 2).Render(content)
 }
 
 func (m Model) renderFindResultsMinibuffer() string {
@@ -279,7 +254,7 @@ func (m Model) renderFindResultsMinibuffer() string {
 
 	header := fmt.Sprintf("Search results for '%s' (%d matches):",
 		m.lastSearchQuery, len(m.findResults))
-	lines = append(lines, minibufferPromptStyle.Render(header))
+	lines = append(lines, MinibufferPromptStyle.Render(header))
 
 	textLines := m.textBuffer.GetLines()
 	start := m.searchResultsOffset
@@ -296,8 +271,8 @@ func (m Model) renderFindResultsMinibuffer() string {
 		if result.Line < len(textLines) {
 			line := textLines[result.Line]
 
-			contextStart := max(0, result.Column-30)
-			contextEnd := min(len(line), result.Column+len(m.lastSearchQuery)+30)
+			contextStart := max(0, result.Column-SearchContextLength)
+			contextEnd := min(len(line), result.Column+len(m.lastSearchQuery)+SearchContextLength)
 
 			linePreview = line[contextStart:contextEnd]
 
@@ -308,8 +283,8 @@ func (m Model) renderFindResultsMinibuffer() string {
 				linePreview = linePreview + "..."
 			}
 
-			if len(linePreview) > 70 {
-				linePreview = linePreview[:67] + "..."
+			if len(linePreview) > LinePreviewMaxLength {
+				linePreview = linePreview[:LinePreviewTruncate] + "..."
 			}
 
 			linePreview = strings.ReplaceAll(linePreview, "\t", "    ")
@@ -321,20 +296,20 @@ func (m Model) renderFindResultsMinibuffer() string {
 			result.Line+1, result.Column+1, linePreview)
 
 		if isSelected {
-			resultText = searchResultSelectedStyle.Render(resultText)
+			resultText = SearchResultSelectedStyle.Render(resultText)
 		} else {
-			resultText = searchResultNormalStyle.Render(resultText)
+			resultText = SearchResultNormalStyle.Render(resultText)
 		}
 
 		lines = append(lines, resultText)
 	}
 
 	hint := "Esc: cancel"
-	lines = append(lines, helpStyle.Render(hint))
+	lines = append(lines, HelpStyle.Render(hint))
 
 	content := strings.Join(lines, "\n")
 
-	return minibufferStyle.
+	return MinibufferStyle.
 		Width(m.width - 2).
 		Render(content)
 }

--- a/modelupdate.go
+++ b/modelupdate.go
@@ -8,19 +8,19 @@ import (
 type keyHandler func(m Model, msg tea.KeyMsg) (tea.Model, tea.Cmd)
 
 var keyHandlers = map[string]keyHandler{
-	"quit":       handleQuit,
-	"save":       handleSave,
+	"quit":       func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m, tea.Quit },
+	"save":       func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleSave() },
 	"help":       handleHelp,
 	"goto":       handleGoToLine,
 	"find":       handleFind,
-	"findNext":   handleFindNext,
-	"findPrev":   handleFindPrev,
-	"copy":       handleCopy,
-	"cut":        handleCut,
-	"paste":      handlePaste,
-	"undo":       handleUndo,
-	"redo":       handleRedo,
-	"selectAll":  handleSelectAll,
+	"findNext":   func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleFindNext() },
+	"findPrev":   func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleFindPrev() },
+	"copy":       func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleCopy() },
+	"cut":        func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleCut() },
+	"paste":      func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handlePaste() },
+	"undo":       func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleUndo() },
+	"redo":       func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleRedo() },
+	"selectAll":  func(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) { return m.handleSelectAll() },
 	"shiftLeft":  handleShiftLeft,
 	"shiftRight": handleShiftRight,
 	"shiftUp":    handleShiftUp,
@@ -32,8 +32,11 @@ var keyHandlers = map[string]keyHandler{
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
+		// Enforce minimum terminal size to prevent UI breakage
+		m.width = max(msg.Width, MinTerminalWidth)
+		m.height = max(msg.Height, MinTerminalHeight)
+		// Ensure cursor remains visible after resize
+		m.ensureCursorVisible()
 		return m, nil
 
 	case tea.KeyMsg:
@@ -217,14 +220,6 @@ func handleTextModification(m Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func handleQuit(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m, tea.Quit
-}
-
-func handleSave(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleSave()
-}
-
 func handleHelp(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.showHelp = !m.showHelp
 	return m, nil
@@ -242,38 +237,6 @@ func handleFind(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.minibufferInput = ""
 	m.minibufferCursorPos = 0
 	return m, nil
-}
-
-func handleFindNext(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleFindNext()
-}
-
-func handleFindPrev(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleFindPrev()
-}
-
-func handleCopy(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleCopy()
-}
-
-func handleCut(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleCut()
-}
-
-func handlePaste(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handlePaste()
-}
-
-func handleUndo(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleUndo()
-}
-
-func handleRedo(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleRedo()
-}
-
-func handleSelectAll(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {
-	return m.handleSelectAll()
 }
 
 func handleShiftLeft(m Model, _ tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/styles.go
+++ b/styles.go
@@ -1,0 +1,115 @@
+package main
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	StatusBarStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorPrimary)).
+			Foreground(lipgloss.Color(ColorBright)).
+			Padding(0, 1)
+
+	HelpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorDim))
+
+	ModifiedStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorPrimary)).
+			Foreground(lipgloss.Color(ColorAlert)).
+			Bold(true)
+
+	EditorStyle = lipgloss.NewStyle().
+			Border(lipgloss.ThickBorder()).
+			BorderForeground(lipgloss.Color(ColorBorder)).
+			Padding(0, 1)
+
+	LineNumberStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorMuted)).
+			Width(4).
+			Align(lipgloss.Right)
+
+	SelectedTextStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorHighlight)).
+			Foreground(lipgloss.Color(ColorForeground))
+
+	CurrentWordStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorSelection)).
+			Foreground(lipgloss.Color(ColorForeground))
+
+	CursorLineStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorBackground))
+
+	HelpBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color(ColorBorder)).
+			AlignHorizontal(lipgloss.Center).
+			Padding(1, 2).
+			Margin(1, 0)
+
+	HelpTitleStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorPrimary)).
+			Bold(true).
+			Underline(true)
+
+	HelpKeyStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorAccent)).
+			Bold(true)
+
+	HelpDescStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorText))
+
+	// Minibuffer styles
+	MinibufferStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorSelection)).
+			Foreground(lipgloss.Color(ColorForeground)).
+			Padding(0, 1)
+
+	MinibufferPromptStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorAccent)).
+			Bold(true)
+
+	MinibufferInputStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorForeground))
+
+	MinibufferCursorStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorForeground)).
+			Foreground(lipgloss.Color(ColorBackground))
+
+	SearchResultSelectedStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(ColorMinibuffer)).
+			Foreground(lipgloss.Color(ColorMinibufferBg)).
+			Bold(true)
+
+	SearchResultNormalStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorInfo))
+
+	// Message styles
+	SuccessMessageStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorSuccess))
+
+	ErrorMessageStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorError))
+
+	WarningMessageStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorWarning))
+
+	// Status bar section styles
+	StatusBarLeftStyle = func(width int) lipgloss.Style {
+		return lipgloss.NewStyle().
+			Width(width / StatusBarSections).
+			Align(lipgloss.Left).
+			Background(lipgloss.Color(ColorPrimary))
+	}
+
+	StatusBarCenterStyle = func(width int) lipgloss.Style {
+		return lipgloss.NewStyle().
+			Width(width / StatusBarSections).
+			Align(lipgloss.Center).
+			Background(lipgloss.Color(ColorPrimary))
+	}
+
+	StatusBarRightStyle = func(width int) lipgloss.Style {
+		return lipgloss.NewStyle().
+			Width(width / StatusBarSections).
+			Align(lipgloss.Right).
+			Background(lipgloss.Color(ColorPrimary))
+	}
+)

--- a/utils.go
+++ b/utils.go
@@ -145,24 +145,11 @@ func (m *Model) centerCursorOnScreen() {
 	m.scrollOffset = targetOffset
 }
 
-func (m Model) normalizeSelection(selection *Selection) (Position, Position) {
-	if selection == nil {
-		cursor := m.textBuffer.GetCursor()
-		return cursor, cursor
-	}
 
-	start, end := selection.Start, selection.End
-
-	if start.Line > end.Line || (start.Line == end.Line && start.Column > end.Column) {
-		start, end = end, start
-	}
-
-	return start, end
-}
 
 func (m Model) saveFile() error {
 	content := m.textBuffer.GetContent()
-	return os.WriteFile(m.filename, []byte(content), 0644)
+	return os.WriteFile(m.filename, []byte(content), FilePermissions)
 }
 
 func copyToClipboard(text string) error {


### PR DESCRIPTION
Move color constants, UI layout constants, and style definitions to dedicated files (constants.go and styles.go) for better organization and maintainability. Update all references to use these constants.

Add current word highlighting feature in text editor. Improve terminal resize handling with minimum size constraints. Clean up redundant handler functions in modelupdate.go.